### PR TITLE
Silence generate script

### DIFF
--- a/duo_gen.py
+++ b/duo_gen.py
@@ -13,11 +13,15 @@ secret = f.readline()[0:-1]
 offset = f.tell()
 count = int(f.readline())
 
-print("secret", secret)
-print("count", count)
+debug = False
 
 hotp = pyotp.HOTP(secret)
-print("Code:", hotp.at(count))
+if debug:
+    print("secret", secret)
+    print("count", count)
+    print("code:", hotp.at(count))
+else:
+    print(hotp.at(count))
 
 f.seek(offset)
 f.write(str(count + 1))


### PR DESCRIPTION
To make use of `duo_generate.py` in other scripts, silence by default.

I didn't feel the need to parse additional arguments or environment variables. No particular reason.